### PR TITLE
Fixed GetLogEntries

### DIFF
--- a/TS3QueryLib.Core.Silverlight/Server/Entities/LogEntry.cs
+++ b/TS3QueryLib.Core.Silverlight/Server/Entities/LogEntry.cs
@@ -9,7 +9,8 @@ namespace TS3QueryLib.Core.Server.Entities
         #region Properties
 
         public DateTime TimeStamp { get; protected set; }
-        public string Channel { get; protected set; } 
+        public uint LastPos { get; protected set; }
+        public uint FileSize { get; protected set; }
 
         #endregion
 
@@ -29,12 +30,14 @@ namespace TS3QueryLib.Core.Server.Entities
             if (currentParameterGroup == null)
                 throw new ArgumentNullException("currentParameterGroup");
 
+            String message = currentParameterGroup.GetParameterValue("l");
+
             return new LogEntry
             {
-                TimeStamp = new DateTime(1970, 1, 1).AddSeconds(currentParameterGroup.GetParameterValue<ulong>("timestamp")),
-                LogLevel = (LogLevel)currentParameterGroup.GetParameterValue<uint>("level"),
-                Channel = currentParameterGroup.GetParameterValue("channel"),
-                Message = currentParameterGroup.GetParameterValue("msg")
+                LastPos = firstParameterGroup.GetParameterValue<uint>("last_pos"),
+                FileSize = firstParameterGroup.GetParameterValue<uint>("file_size"),
+                Message = message,
+                TimeStamp = DateTime.Parse(message.Split('|')[0])
             };
         }
 

--- a/TS3QueryLib.Core.Silverlight/Server/Entities/LogEntryLight.cs
+++ b/TS3QueryLib.Core.Silverlight/Server/Entities/LogEntryLight.cs
@@ -7,7 +7,6 @@ namespace TS3QueryLib.Core.Server.Entities
     {
         #region Properties
 
-        public LogLevel LogLevel { get; set; }
         public string Message { get; set; }
 
         #endregion
@@ -19,12 +18,11 @@ namespace TS3QueryLib.Core.Server.Entities
             
         }
 
-        public LogEntryLight(LogLevel logLevel, string message)
+        public LogEntryLight(string message)
         {
             if (message.IsNullOrTrimmedEmpty())
                 throw new ArgumentException("message is null or trimmed empty");
 
-            LogLevel = logLevel;
             Message = message;
         }
 


### PR DESCRIPTION
This fixes #1 
- Removed "LogLevel", "Channel" and "Message from LogEntry(Light)
- Added "LastPos" and "FileSize" to LogEntry
- Changed how Timestamps get parsed in LogEntry
- Removed "timestamp" and "comparator" from QueryRunner, since they can't be used anymore
- Updated GetLogEntries + Documentation

If you found any Code-Style issues, let me know and I will fix it :smiley: 
