### PR TITLE
Added following channel properties in ChannelInfoResponse:

### DIFF
--- a/TS3QueryLib.Core.Silverlight/Server/Responses/ChannelInfoResponse.cs
+++ b/TS3QueryLib.Core.Silverlight/Server/Responses/ChannelInfoResponse.cs
@@ -8,7 +8,7 @@ namespace TS3QueryLib.Core.Server.Responses
     {
         #region Properties
 
-		public uint ParentChannelId { get; protected set; }
+        public uint ParentChannelId { get; protected set; }
         public string Name { get; protected set; }
         public string Topic { get; protected set; }
         public string Description { get; protected set; }
@@ -22,6 +22,10 @@ namespace TS3QueryLib.Core.Server.Responses
         public bool IsSemiPermanent { get; protected set; }
         public bool IsDefaultChannel { get; protected set; }
         public bool IsPasswordProtected { get; protected set; }
+        public uint LatencyFactor { get; protected set; }
+        public bool IsUnencrypted { get; protected set; }
+        public string SecuritySalt { get; protected set; }
+        public uint DeleteDelay { get; protected set; }
         public bool IsMaxClientsUnlimited { get; protected set; }
         public bool IsMaxFamilyClientsUnlimited { get; protected set; }
         public bool IsMaxFamilyClientsInherited { get; protected set; }
@@ -30,6 +34,7 @@ namespace TS3QueryLib.Core.Server.Responses
         public bool ForcedSilence { get; protected set; }
         public string PhoneticName { get; protected set; }
         public uint IconId { get; protected set; }
+        public int SecondsEmpty { get; protected set; }
 
         #endregion
 
@@ -42,7 +47,7 @@ namespace TS3QueryLib.Core.Server.Responses
             if (list.Count == 0)
                 return;
 
-			ParentChannelId = list.GetParameterValue<uint>("pid");
+            ParentChannelId = list.GetParameterValue<uint>("pid");
             Name = list.GetParameterValue("channel_name");
             Topic = list.GetParameterValue("channel_topic");
             Description = list.GetParameterValue("channel_description");
@@ -52,10 +57,14 @@ namespace TS3QueryLib.Core.Server.Responses
             MaxClients = list.GetParameterValue<int>("channel_maxclients");
             MaxFamilyClients = list.GetParameterValue<int>("channel_maxfamilyclients");
             Order = list.GetParameterValue<uint>("channel_order");
-            IsDefaultChannel = list.GetParameterValue("channel_flag_default").ToBool();
-            IsPasswordProtected = list.GetParameterValue("channel_flag_password").ToBool();
             IsPermanent = list.GetParameterValue("channel_flag_permanent").ToBool();
             IsSemiPermanent = list.GetParameterValue("channel_flag_semi_permanent").ToBool();
+            IsDefaultChannel = list.GetParameterValue("channel_flag_default").ToBool();
+            IsPasswordProtected = list.GetParameterValue("channel_flag_password").ToBool();
+            LatencyFactor = list.GetParameterValue<uint>("channel_codec_latency_factor");
+            IsUnencrypted = list.GetParameterValue("channel_codec_is_unencrypted").ToBool();
+            SecuritySalt = list.GetParameterValue("channel_security_salt");
+            DeleteDelay = list.GetParameterValue<uint>("channel_delete_delay");
             IsMaxClientsUnlimited = list.GetParameterValue("channel_flag_maxclients_unlimited").ToBool();
             IsMaxFamilyClientsUnlimited = list.GetParameterValue("channel_flag_maxfamilyclients_unlimited").ToBool();
             IsMaxFamilyClientsInherited = list.GetParameterValue("channel_flag_maxfamilyclients_inherited").ToBool();
@@ -64,6 +73,8 @@ namespace TS3QueryLib.Core.Server.Responses
             ForcedSilence = list.GetParameterValue("channel_forced_silence").ToBool();
             PhoneticName = list.GetParameterValue("channel_name_phonetic");
             IconId = list.GetParameterValue<uint>("channel_icon_id");
+            // channel_flag_private=0 | Not implemented yet by TeamSpeak.
+            SecondsEmpty = list.GetParameterValue<int>("seconds_empty");
         }
 
         #endregion


### PR DESCRIPTION
- uint LatencyFactor
- bool IsUnencrypted
- string SecuritySalt
- uint DeleteDelay
- int SecondsEmpty

channel_flag_private is not implemented yet by TeamSpeak so it doesn't make sense to implement this property.
