### PR TITLE
Update AsyncTcpDispatcher.cs [Performance increase]

### DIFF
--- a/TS3QueryLib.Core.Silverlight/AsyncTcpDispatcher.cs
+++ b/TS3QueryLib.Core.Silverlight/AsyncTcpDispatcher.cs
@@ -228,7 +228,7 @@ namespace TS3QueryLib.Core
 
                         
 
-                        if(_receiveRepository.ToString().Contains("error id="))//performance fix (mainly for permissionlist)
+                        if(_receiveRepository.ToString().IndexOf("error id=", StringComparison.InvariantCultureIgnoreCase)!=-1)//performance fix (mainly for permissionlist)
                         {
                             Match statusLineMatch = StatusLineMatch(_receiveRepository.ToString());
     


### PR DESCRIPTION
1.Fix:
Somehow the SocketAsyncEventArgs were null for me sometime, so I checked if it is null...

2.Fix:
If trying to get the permissionlist it took from 90 to 120 Seconds (on localhost) to get it.
The problem was the regex checking every time the buffer was full.
Now I check if the statusline could be reached before trying to get it with regex, which increases the performance to a few seconds...