### PR TITLE
Try-catch for unhandled ObjectDisposedException

### DIFF
--- a/TS3QueryLib.Core.Framework/AsyncTcpDispatcher.cs
+++ b/TS3QueryLib.Core.Framework/AsyncTcpDispatcher.cs
@@ -171,12 +171,19 @@ namespace TS3QueryLib.Core
         {
             EnsureSocketSuccess(socketAsyncEventArgs, () =>
             {
-                SocketAsyncEventArgsUserToken userToken = (SocketAsyncEventArgsUserToken)socketAsyncEventArgs.UserToken;
+                try
+                {
+                    SocketAsyncEventArgsUserToken userToken = (SocketAsyncEventArgsUserToken)socketAsyncEventArgs.UserToken;
 
-                byte[] sizeBuffer = new byte[RECEIVE_BUFFER_SIZE];
-                socketAsyncEventArgs.SetBuffer(sizeBuffer, 0, sizeBuffer.Length);
+                    byte[] sizeBuffer = new byte[RECEIVE_BUFFER_SIZE];
+                    socketAsyncEventArgs.SetBuffer(sizeBuffer, 0, sizeBuffer.Length);
 
-                userToken.Socket.InvokeAsyncMethod(userToken.Socket.ReceiveAsync, MessageReceived, socketAsyncEventArgs);
+                    userToken.Socket.InvokeAsyncMethod(userToken.Socket.ReceiveAsync, MessageReceived, socketAsyncEventArgs);
+                }
+                catch (ObjectDisposedException)
+                {
+
+                }
             });
         }
 


### PR DESCRIPTION
When disconnecting and connecting to the client query (for example because teamspeak got closed and opened again), I often get a "ProtocolNotSupported" error message.
This leads to an unhandled _ObjectDisposedException_ in the AsyncTcpDispatcher and thus crashes the program which makes use of TS3QueryLib.Net.