### PR TITLE
Add missing SecondsEmpty param parsing and request. 

### DIFF
--- a/TS3QueryLib.Core.Framework/Common/Entities/ChannelListEntryBase.cs
+++ b/TS3QueryLib.Core.Framework/Common/Entities/ChannelListEntryBase.cs
@@ -74,6 +74,13 @@ namespace TS3QueryLib.Core.Common.Entities
         public uint? ChannelIconId { get; protected set; }
 
         #endregion
+
+        #region "SecondsEmpty-Properties"
+
+        public TimeSpan? ChannelEmptyDuration { get; protected set; }
+
+        #endregion
+
         #endregion
 
         #region Public Methods
@@ -104,6 +111,10 @@ namespace TS3QueryLib.Core.Common.Entities
             MaxClients = currrentParameterGroup.GetParameterValue<int?>("channel_maxclients");
             MaxFamilyClients = currrentParameterGroup.GetParameterValue<int?>("channel_maxfamilyclients");
             ChannelIconId = currrentParameterGroup.GetParameterValue<uint?>("channel_icon_id");
+
+            // Seconds empty
+            int? emptySeconds = currrentParameterGroup.GetParameterValue<int?>("seconds_empty");
+            ChannelEmptyDuration = emptySeconds.HasValue ? (TimeSpan?)TimeSpan.FromSeconds(emptySeconds.Value) : null;
         }
 
         #endregion

--- a/TS3QueryLib.Core.Framework/Server/QueryRunner.cs
+++ b/TS3QueryLib.Core.Framework/Server/QueryRunner.cs
@@ -1016,7 +1016,7 @@ namespace TS3QueryLib.Core.Server
 
         public ListResponse<ChannelListEntry> GetChannelList(bool includeAll)
         {
-            return GetChannelList(includeAll, false, false, false, false, false, true);
+            return GetChannelList(includeAll, false, false, false, false, false, false);
         }
 
         /// <summary>

--- a/TS3QueryLib.Core.Framework/Server/QueryRunner.cs
+++ b/TS3QueryLib.Core.Framework/Server/QueryRunner.cs
@@ -1016,7 +1016,7 @@ namespace TS3QueryLib.Core.Server
 
         public ListResponse<ChannelListEntry> GetChannelList(bool includeAll)
         {
-            return GetChannelList(includeAll, false, false, false, false, false);
+            return GetChannelList(includeAll, false, false, false, false, false, true);
         }
 
         /// <summary>
@@ -1027,12 +1027,12 @@ namespace TS3QueryLib.Core.Server
         /// <param name="includeVoiceInfo">if set to true voice parameters are included</param>
         /// <param name="includeLimits">if set to true limit parameters are included</param>
         /// <param name="includeIcon">if set to true icon parameter is included</param>
-        public ListResponse<ChannelListEntry> GetChannelList(bool includeTopics, bool includeFlags, bool includeVoiceInfo, bool includeLimits, bool includeIcon)
+        public ListResponse<ChannelListEntry> GetChannelList(bool includeTopics, bool includeFlags, bool includeVoiceInfo, bool includeLimits, bool includeIcon, bool includeEmpty)
         {
-            return GetChannelList(false, includeTopics, includeFlags, includeVoiceInfo, includeLimits, includeIcon);
+            return GetChannelList(false, includeTopics, includeFlags, includeVoiceInfo, includeLimits, includeIcon, includeEmpty);
         }
 
-        private ListResponse<ChannelListEntry> GetChannelList(bool includeAll, bool includeTopics, bool includeFlags, bool includeVoiceInfo, bool includeLimits, bool includeIcon)
+        private ListResponse<ChannelListEntry> GetChannelList(bool includeAll, bool includeTopics, bool includeFlags, bool includeVoiceInfo, bool includeLimits, bool includeIcon, bool includeEmpty)
         {
             Command command = CommandName.ChannelList.CreateCommand();
 
@@ -1050,6 +1050,9 @@ namespace TS3QueryLib.Core.Server
 
             if (includeIcon || includeAll)
                 command.AddOption("icon");
+
+            if (includeEmpty || includeAll)
+                command.AddOption("secondsempty");
 
             return ListResponse<ChannelListEntry>.Parse(SendCommand(command), ChannelListEntry.Parse);
         }


### PR DESCRIPTION
Based on query command 'channellist':
/// Query info:
/// Usage: channellist [-topic] [-flags] [-voice] [-limits] [-icon] [-secondsempty]
///
/// Displays a list of channels created on a virtual server including their ID,
/// order, name, etc. The output can be modified using several command options.
///
/// Example:
/// channellist -topic
/// cid=15 pid=0 channel_order=0 channel_name=Default\sChannel
/// channel_topic=No\s[b]topic[\/b] total_clients=2|cid=16 ...
/// error id=0 msg=ok

Added a new option 'includeEmpty' in the GetChannel command.
Added a new parameter 'ChannelEmptyDuration' as timespan to parse this option.

Basic description:
- seconds_empty it's a param which starts counting on the server side from the moment when the channel gets empty.

Example:
- If i'm on channel xaxa[id 123], seconds_empty it's -1
- If i leave the channel, seconds_empty starts counting in seconds since the last time someone was on the channel.